### PR TITLE
feat: added a new flag that displays the number of tokens sent in prompt and received in completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,14 +36,14 @@ Files to be used can be placed anywhere as long as you provide the appropriate p
 
 # Flag options
 
-| flag                | description                                                                                                              | usage                                                                         |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------- |
-| -v<br>--version     | Displays the tool's name and the current version.                                                                        | **genereadme** -v<br>**genereadme** --version                                 |
-| -o<br>--output      | Writes the generated result into the specified filename.                                                                 | **genereadme** -o `filename`<br>**genereadme** --output `filename`            |
-| -a<br>--api-key     | Allows you to provide your own API key to use for Groq API.                                                              | **genereadme** -a `key`<br>**genereadme** --api-key `key`                     |
-| -t<br>--temperature | Allows your to provide your preferred temperature for the chat completion generation. Currently supports `0.1` to `1.5`. | **genereadme** -t `temperature`<br>**genereadme** --temperature `temperature` |
-| --token-usage       | Shows the count of the tokens sent in the `prompt` and returned in the `completion`                                      | **genereadme** --token-usage `filename`                                       |
-| -h<br>--help        | Displays how to use the tool, the arguments accepted, and the available flags.                                           | **genereadme** -h<br>**genereadme** --help                                    |
+| flag                 | description                                                                                                              | usage                                                                         |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------- |
+| -v<br>--version      | Displays the tool's name and the current version.                                                                        | **genereadme** -v<br>**genereadme** --version                                 |
+| -o<br>--output       | Writes the generated result into the specified filename.                                                                 | **genereadme** -o `filename`<br>**genereadme** --output `filename`            |
+| -a<br>--api-key      | Allows you to provide your own API key to use for Groq API.                                                              | **genereadme** -a `key`<br>**genereadme** --api-key `key`                     |
+| -t<br>--temperature  | Allows your to provide your preferred temperature for the chat completion generation. Currently supports `0.1` to `1.5`. | **genereadme** -t `temperature`<br>**genereadme** --temperature `temperature` |
+| -tu<br>--token-usage | Shows the count of the tokens sent in the `prompt` and returned in the `completion`                                      | **genereadme** -tu `filename`<br>**genereadme** --token-usage `filename`      |
+| -h<br>--help         | Displays how to use the tool, the arguments accepted, and the available flags.                                           | **genereadme** -h<br>**genereadme** --help                                    |
 
 <br/>
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Files to be used can be placed anywhere as long as you provide the appropriate p
 | -o<br>--output      | Writes the generated result into the specified filename.                                                                 | **genereadme** -o `filename`<br>**genereadme** --output `filename`            |
 | -a<br>--api-key     | Allows you to provide your own API key to use for Groq API.                                                              | **genereadme** -a `key`<br>**genereadme** --api-key `key`                     |
 | -t<br>--temperature | Allows your to provide your preferred temperature for the chat completion generation. Currently supports `0.1` to `1.5`. | **genereadme** -t `temperature`<br>**genereadme** --temperature `temperature` |
+| --token-usage       | Shows the count of the tokens sent in the `prompt` and returned in the `completion`                                      | **genereadme** --token-usage `filename`                                       |
 | -h<br>--help        | Displays how to use the tool, the arguments accepted, and the available flags.                                           | **genereadme** -h<br>**genereadme** --help                                    |
 
 <br/>

--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ program
     "-t, --temperature <temperature>",
     "Temperature for the chat completions"
   )
+  .option("--token-usage", "Show prompt and completion token usage")
   .configureOutput({
     outputError: (str) => {
       if (str.includes("error: missing required argument")) {
@@ -65,6 +66,9 @@ program
           );
         }
       }
+
+      let promptTokens = 0;
+      let completionTokens = 0;
 
       let combinedContent = "";
       for (const file of files) {
@@ -121,6 +125,9 @@ program
           return;
         }
 
+        promptTokens += response.usage.prompt_tokens;
+        completionTokens += response.usage.completion_tokens;
+
         if (response.choices[0].message.content === "Invalid file") {
           throw new Error(
             "The file passed is either not majorly a source code, does not contain any code, or is not a valid file."
@@ -149,6 +156,11 @@ program
         fs.writeFileSync(outputFile, combinedContent, "utf-8");
         console.log(`${outputFile} has been generated successfully!`);
         console.log(`${combinedContent}`);
+      }
+
+      if (program.opts().tokenUsage) {
+        console.error(`Prompt tokens: ${promptTokens}`);
+        console.error(`Completion tokens: ${completionTokens}`);
       }
     } catch (error) {
       console.error("Error generating README:", error.message);

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ program
     "-t, --temperature <temperature>",
     "Temperature for the chat completions"
   )
-  .option("--token-usage", "Show prompt and completion token usage")
+  .option("-tu, --token-usage", "Show prompt and completion token usage")
   .configureOutput({
     outputError: (str) => {
       if (str.includes("error: missing required argument")) {


### PR DESCRIPTION
# Description

Closes #12.

- Added a new flag `--token-usage` which when given, prints the number of tokens that were sent in the `prompt` and the number of tokens that were returned in the `completion` to `stderr.

This simply required the addition for another flag check `--token-usage`:

```javascript
   .option("--token-usage", "Show prompt and completion token usage")
```

I've also made sure to keep your naming conventions/formatting style consistent, in the for loop that does the chat completion for each file processed, I have accumulated the total tokens `sent` and received:

```javascript
    promptTokens += response.usage.prompt_tokens;
    completionTokens += response.usage.completion_tokens;
```

which I then display at the end of program run-time if the `--token-usage` flag is provided as such:

```javascript
    if (program.opts().tokenUsage) {
      console.error(`Prompt tokens: ${promptTokens}`);
      console.error(`Completion tokens: ${completionTokens}`);
    }
```

- Updated `README.md` to explain the new flag.

## Testing

### Test 1

```bash
genereadme examples/sum.js --token-usage
```

This should display something like:

![image](https://github.com/user-attachments/assets/aad09082-05c7-4312-97fe-cd8f00c2891e)

### Test 2

You can try it out with multiple files too, i.e.:

```bash
genereadme examples/sum.js examples/createUser.js --token-usage
```
