### PR TITLE
Add TOML config file parsing for specifying options 

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,26 @@ Files to be used can be placed anywhere as long as you provide the appropriate p
 
 <br/>
 
+# TOML Config File
+
+If you don't want to specify the options as command line arguments, you could add an optional TOML config file.
+
+Create `genereadme-config.toml` in your home directory. For eg. in windows, it is:  `C:\Users\yourusername`
+
+Here is an example:
+
+`genereadme-config.toml`
+```
+apiKey = "yourAPIkey"
+temperature = 0.5
+tokenUsage = true
+```
+
+If you want to override any of the options, you can enter them as command line arguments.
+
+
+<br/>
+
 # Dependencies
 
 ### [OpenAI](https://openai.com/)

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "commander": "^12.1.0",
         "dotenv": "^16.4.5",
         "fs": "^0.0.1-security",
-        "openai": "^4.63.0"
+        "openai": "^4.63.0",
+        "toml": "^3.0.0"
       },
       "bin": {
         "genereadme": "src/main.js"
@@ -237,6 +238,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/toml": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
+      "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==",
+      "license": "MIT"
     },
     "node_modules/tr46": {
       "version": "0.0.3",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "commander": "^12.1.0",
     "dotenv": "^16.4.5",
     "fs": "^0.0.1-security",
-    "openai": "^4.63.0"
+    "openai": "^4.63.0",
+    "toml": "^3.0.0"
   }
 }

--- a/src/commander/argHandlers.js
+++ b/src/commander/argHandlers.js
@@ -1,15 +1,19 @@
 import program from "./setup.js";
+import { readConfigFile } from "../../utils/readConfig.js";
 
 /**
  * Retrieves the flag options in the command line arguments.
  * @returns {Object} The options object.
  */
 export function getOptions() {
-  const apiKey = program.opts().apiKey;
-  const provider = program.opts().provider;
-  const outputFile = program.opts().output;
-  const temperature = program.opts().temperature;
-  const tokenUsage = program.opts().tokenUsage;
+
+   //If arguments are passed in the command line, they will override the config file values.
+  const config = readConfigFile();
+  const apiKey = program.opts().apiKey || config.apiKey;
+  const provider = program.opts().provider || config.provider;
+  const outputFile = program.opts().output || config.outputFile;
+  const temperature = program.opts().temperature  || config.temperature;
+  const tokenUsage = program.opts().tokenUsage || config.tokenUsage;
 
   if (outputFile && !outputFile.endsWith(".md")) {
     throw new Error(
@@ -23,14 +27,5 @@ export function getOptions() {
     );
   }
 
-  const options = { apiKey, provider, outputFile, temperature, tokenUsage };
-
-  // Remove undefined properties
-  Object.keys(options).forEach(key => {
-    if (options[key] === undefined) {
-      delete options[key];
-    }
-  });
-
-  return options;
+  return { apiKey, provider, outputFile, temperature, tokenUsage };
 }

--- a/src/commander/argHandlers.js
+++ b/src/commander/argHandlers.js
@@ -23,5 +23,14 @@ export function getOptions() {
     );
   }
 
-  return { apiKey, provider, outputFile, temperature, tokenUsage };
+  const options = { apiKey, provider, outputFile, temperature, tokenUsage };
+
+  // Remove undefined properties
+  Object.keys(options).forEach(key => {
+    if (options[key] === undefined) {
+      delete options[key];
+    }
+  });
+
+  return options;
 }

--- a/src/commander/argHandlers.js
+++ b/src/commander/argHandlers.js
@@ -6,11 +6,9 @@ import program from "./setup.js";
  */
 export function getOptions() {
   const apiKey = program.opts().apiKey;
-  const provider = program.opts().provider || "Groq";
+  const provider = program.opts().provider;
   const outputFile = program.opts().output;
-  const temperature = program.opts().temperature
-    ? parseFloat(program.opts().temperature)
-    : 0.7;
+  const temperature = program.opts().temperature;
   const tokenUsage = program.opts().tokenUsage;
 
   if (outputFile && !outputFile.endsWith(".md")) {

--- a/src/main.js
+++ b/src/main.js
@@ -3,17 +3,11 @@ import fs from "fs";
 import program from "./commander/setup.js";
 import { getOptions } from "./commander/argHandlers.js";
 import generateCompletion from "./openai/generateCompletion.js";
-import { readConfigFile } from "../utils/readConfig.js";
 
 program.action(async (files) => {
   try {
-    const config = readConfigFile();
-    const options = getOptions();
-    
-    //If arguments are passed in the command line, they will override the config file
-    const finalOptions = { ...config, ...options };
 
-    const { apiKey, provider, outputFile, temperature, tokenUsage } = finalOptions;
+    const { apiKey, provider, outputFile, temperature, tokenUsage } = getOptions();
 
     let totalPromptTokensUsed = 0;
     let totalCompletionTokensUsed = 0;

--- a/src/main.js
+++ b/src/main.js
@@ -62,6 +62,7 @@ program.action(async (files) => {
 });
 
 function readConfigFile() {
+  
   const homeDir = os.homedir();
   const configFilePath = path.join(homeDir, "./genereadme-config.toml");
 

--- a/src/main.js
+++ b/src/main.js
@@ -3,15 +3,12 @@ import fs from "fs";
 import program from "./commander/setup.js";
 import { getOptions } from "./commander/argHandlers.js";
 import generateCompletion from "./openai/generateCompletion.js";
-import { readConfigFile } from "./utils/readConfig.js";
+import { readConfigFile } from "../utils/readConfig.js";
 
 program.action(async (files) => {
   try {
     const config = readConfigFile();
     const options = getOptions();
-
-    // Filter out undefined values from options
-    Object.keys(options).forEach(key => options[key] === undefined ? delete options[key] : {})
     
     //If arguments are passed in the command line, they will override the config file
     const finalOptions = { ...config, ...options };

--- a/src/main.js
+++ b/src/main.js
@@ -1,14 +1,30 @@
 #!/usr/bin/env node
 
 import fs from "fs";
+import path from "path";
+import os from "os";
+import toml from "toml";
 import program from "./commander/setup.js";
 import { getOptions } from "./commander/argHandlers.js";
 import generateCompletion from "./openai/generateCompletion.js";
 
 program.action(async (files) => {
   try {
-    const { apiKey, provider, outputFile, temperature, tokenUsage } =
-      getOptions();
+    const config = readConfigFile();
+    console.log("Config file content:", config);
+    const options = getOptions();
+    console.log("Options:", options);
+
+    // Filter out undefined values from options
+    Object.keys(options).forEach(key => options[key] === undefined ? delete options[key] : {})
+
+    console.log("Filtered Options:", options);
+    
+    const finalOptions = { ...config, ...options };
+
+    const { apiKey, provider, outputFile, temperature, tokenUsage } = finalOptions;
+
+    console.log("Final Options:", finalOptions);
 
     let totalPromptTokensUsed = 0;
     let totalCompletionTokensUsed = 0;
@@ -49,6 +65,23 @@ program.action(async (files) => {
     process.exit(1);
   }
 });
+
+function readConfigFile() {
+  const homeDir = os.homedir();
+  const configFilePath = path.join(homeDir, "./genereadme-config.toml");
+
+  if (fs.existsSync(configFilePath)) {
+    try {
+      const configFileContent = fs.readFileSync(configFilePath, "utf-8");
+     
+      return toml.parse(configFileContent);
+    } catch (error) {
+      console.error("Error parsing the config file:", error.message);
+      process.exit(1);
+    }
+  }
+  return {};
+}
 
 function main() {
   program.parse(process.argv);

--- a/src/main.js
+++ b/src/main.js
@@ -1,12 +1,9 @@
 #!/usr/bin/env node
-
 import fs from "fs";
-import path from "path";
-import os from "os";
-import toml from "toml";
 import program from "./commander/setup.js";
 import { getOptions } from "./commander/argHandlers.js";
 import generateCompletion from "./openai/generateCompletion.js";
+import { readConfigFile } from "./utils/readConfig.js";
 
 program.action(async (files) => {
   try {
@@ -60,24 +57,6 @@ program.action(async (files) => {
     process.exit(1);
   }
 });
-
-function readConfigFile() {
-  
-  const homeDir = os.homedir();
-  const configFilePath = path.join(homeDir, "./genereadme-config.toml");
-
-  if (fs.existsSync(configFilePath)) {
-    try {
-      const configFileContent = fs.readFileSync(configFilePath, "utf-8");
-     
-      return toml.parse(configFileContent);
-    } catch (error) {
-      console.error("Error parsing the config file:", error.message);
-      process.exit(1);
-    }
-  }
-  return {};
-}
 
 function main() {
   program.parse(process.argv);

--- a/src/main.js
+++ b/src/main.js
@@ -11,20 +11,15 @@ import generateCompletion from "./openai/generateCompletion.js";
 program.action(async (files) => {
   try {
     const config = readConfigFile();
-    console.log("Config file content:", config);
     const options = getOptions();
-    console.log("Options:", options);
 
     // Filter out undefined values from options
     Object.keys(options).forEach(key => options[key] === undefined ? delete options[key] : {})
-
-    console.log("Filtered Options:", options);
     
+    //If arguments are passed in the command line, they will override the config file
     const finalOptions = { ...config, ...options };
 
     const { apiKey, provider, outputFile, temperature, tokenUsage } = finalOptions;
-
-    console.log("Final Options:", finalOptions);
 
     let totalPromptTokensUsed = 0;
     let totalCompletionTokensUsed = 0;

--- a/src/openai/generateCompletion.js
+++ b/src/openai/generateCompletion.js
@@ -15,9 +15,9 @@ import generatePrompt from "../prompts/generatePrompt.js";
 export default async function generateCompletion(
   file,
   apiKey,
-  provider,
+  provider="Groq",
   outputFile,
-  temp
+  temp=0.7
 ) {
   const { client, model } = createClient(provider, apiKey);
   const codeContent = fs.readFileSync(file, "utf-8");

--- a/utils/readConfig.js
+++ b/utils/readConfig.js
@@ -1,0 +1,21 @@
+import path from "path";
+import os from "os";
+import toml from "toml";
+
+export function readConfigFile() {
+  
+    const homeDir = os.homedir();
+    const configFilePath = path.join(homeDir, "./genereadme-config.toml");
+  
+    if (fs.existsSync(configFilePath)) {
+      try {
+        const configFileContent = fs.readFileSync(configFilePath, "utf-8");
+       
+        return toml.parse(configFileContent);
+      } catch (error) {
+        console.error("Error parsing the config file:", error.message);
+        process.exit(1);
+      }
+    }
+    return {};
+  }

--- a/utils/readConfig.js
+++ b/utils/readConfig.js
@@ -1,3 +1,4 @@
+import fs from "fs";
 import path from "path";
 import os from "os";
 import toml from "toml";


### PR DESCRIPTION
Based on #17 

Added TOML parsing. The user can create a **genereadme-config.toml** in their home directory. 

By default, the options specified in the file will be used if no command line argument is given to override it.

This makes it easier for the user to specify a common format.

For example, in windows, it is: ```C:\Users\yourusername```